### PR TITLE
update flow to v0.5.0-2-g5fa7e6bcc and update gitpod base image

### DIFF
--- a/flow.Dockerfile
+++ b/flow.Dockerfile
@@ -1,7 +1,7 @@
 # You can find the latest tags here: https://github.com/estuary/flow/pkgs/container/flow
-FROM ghcr.io/estuary/flow:v0.3.12-156-g57e1216a8 as flow_base
+FROM ghcr.io/estuary/flow:v0.5.0-2-g5fa7e6bcc as flow_base
 
 # You can find the new timestamped tags here: https://hub.docker.com/r/gitpod/workspace-base/tags
-FROM gitpod/workspace-base:2023-09-18-16-44-58
+FROM gitpod/workspace-base:2024-08-20-00-26-31
 
 COPY --from=flow_base /usr/local/bin/* /usr/local/bin


### PR DESCRIPTION
Looks like it's been a while since gitpod was updated, so hopefully this fixes it. A number of users are running into errors since the flowctl version in gitpod is so outdated.