### PR TITLE
Don't copy binaries from flow image

### DIFF
--- a/flow.Dockerfile
+++ b/flow.Dockerfile
@@ -1,7 +1,24 @@
-# You can find the latest tags here: https://github.com/estuary/flow/pkgs/container/flow
-FROM ghcr.io/estuary/flow:v0.5.0-2-g5fa7e6bcc as flow_base
-
 # You can find the new timestamped tags here: https://hub.docker.com/r/gitpod/workspace-base/tags
 FROM gitpod/workspace-base:2024-08-20-00-26-31
 
-COPY --from=flow_base /usr/local/bin/* /usr/local/bin
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+    && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg \
+    && sudo apt-get update -y \
+    && DEBIAN_FRONTEND=noninteractive sudo apt-get install --no-install-recommends -y \
+    docker.io \
+    google-cloud-cli \
+    slirp4netns \
+    uidmap \
+    && sudo rm -rf /var/lib/apt/lists/*
+
+
+RUN sudo curl -o /usr/local/bin/flowctl -L 'https://github.com/estuary/flow/releases/latest/download/flowctl-x86_64-linux' \
+    && sudo chmod +x /usr/local/bin/flowctl \
+    && sudo curl -o /usr/local/bin/sops -L https://github.com/getsops/sops/releases/download/v3.9.0/sops-v3.9.0.linux.amd64 \
+    && sudo chmod +x /usr/local/bin/sops \
+    && curl -L -o /tmp/deno.zip https://github.com/denoland/deno/releases/download/v1.32.1/deno-x86_64-unknown-linux-gnu.zip \
+		&& unzip /tmp/deno.zip -d /tmp \
+		&& rm /tmp/deno.zip \
+		&& sudo mv /tmp/deno /usr/local/bin/
+
+


### PR DESCRIPTION
Updates the gitpod dockerfile to stop copying binaries out of the flow docker image. That approach broke when we updated the flow image to use the latest ubuntu image as a base, because the built binaries depend on a newer glibc version than is installed in the gitpod base.

So this updates the gitpod dockerfile to install things the old fashioned way, which will hopefully be more robust.