### PR TITLE
add FLOW_VERSION env variable

### DIFF
--- a/flow.Dockerfile
+++ b/flow.Dockerfile
@@ -1,6 +1,11 @@
 # You can find the new timestamped tags here: https://hub.docker.com/r/gitpod/workspace-base/tags
 FROM gitpod/workspace-base:2024-08-20-00-26-31
 
+# This version number is here in order to invalidate the Gitpod image cache whenever it changes.
+# Otherwise, Gitpod will not know to re-build the image after we release a new flowctl version.
+# From: https://github.com/gitpod-io/gitpod/issues/4126#issuecomment-830593427
+ENV FLOW_VERSION=v0.5.1
+
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
     && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg \
     && sudo apt-get update -y \
@@ -12,7 +17,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.
     && sudo rm -rf /var/lib/apt/lists/*
 
 
-RUN sudo curl -o /usr/local/bin/flowctl -L 'https://github.com/estuary/flow/releases/latest/download/flowctl-x86_64-linux' \
+RUN sudo curl -o /usr/local/bin/flowctl -L "https://github.com/estuary/flow/releases/${FLOW_VERSION}/download/flowctl-x86_64-linux" \
     && sudo chmod +x /usr/local/bin/flowctl \
     && sudo curl -o /usr/local/bin/sops -L https://github.com/getsops/sops/releases/download/v3.9.0/sops-v3.9.0.linux.amd64 \
     && sudo chmod +x /usr/local/bin/sops \


### PR DESCRIPTION
The purpose of this is to invalidate Gitpod's image cache after we release a new flowctl version. Otherwise, Gitpod will continue using the cached image with the old version.